### PR TITLE
Add loan amortization schedule and UI refinements

### DIFF
--- a/app/src/main/java/com/loandesk/controller/LoanApplicationViewController.java
+++ b/app/src/main/java/com/loandesk/controller/LoanApplicationViewController.java
@@ -6,6 +6,7 @@ import com.loandesk.domain.LoanProduct;
 import com.loandesk.repository.CustomerRepository;
 import com.loandesk.repository.LoanApplicationRepository;
 import com.loandesk.repository.LoanProductRepository;
+import com.loandesk.service.LoanCalculatorService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -17,13 +18,16 @@ public class LoanApplicationViewController {
     private final LoanApplicationRepository applicationRepository;
     private final CustomerRepository customerRepository;
     private final LoanProductRepository productRepository;
+    private final LoanCalculatorService calculator;
 
     public LoanApplicationViewController(LoanApplicationRepository applicationRepository,
                                          CustomerRepository customerRepository,
-                                         LoanProductRepository productRepository) {
+                                         LoanProductRepository productRepository,
+                                         LoanCalculatorService calculator) {
         this.applicationRepository = applicationRepository;
         this.customerRepository = customerRepository;
         this.productRepository = productRepository;
+        this.calculator = calculator;
     }
 
     @GetMapping
@@ -49,6 +53,17 @@ public class LoanApplicationViewController {
         app.setStatus("DRAFT");
         applicationRepository.save(app);
         return "redirect:/applications";
+    }
+
+    @GetMapping("/{id}/schedule")
+    public String schedule(@PathVariable Long id, Model model) {
+        LoanApplication app = applicationRepository.findById(id).orElseThrow();
+        model.addAttribute("app", app);
+        model.addAttribute("schedule", calculator.generateSchedule(
+                app.getAmount(),
+                app.getProduct().getInterestRateAnnual(),
+                app.getTermMonths()));
+        return "schedule";
     }
 
     @PostMapping("/{id}/approve")

--- a/app/src/main/java/com/loandesk/domain/LoanApplication.java
+++ b/app/src/main/java/com/loandesk/domain/LoanApplication.java
@@ -27,4 +27,15 @@ public class LoanApplication {
     private int termMonths;
     private String status;
     private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Transient
+    public double getMonthlyPayment() {
+        double annualRate = product.getInterestRateAnnual();
+        double monthlyRate = annualRate / 12.0 / 100.0;
+        if (monthlyRate == 0) {
+            return amount / termMonths;
+        }
+        double factor = Math.pow(1 + monthlyRate, termMonths);
+        return amount * (monthlyRate * factor) / (factor - 1);
+    }
 }

--- a/app/src/main/java/com/loandesk/service/LoanCalculatorService.java
+++ b/app/src/main/java/com/loandesk/service/LoanCalculatorService.java
@@ -1,0 +1,43 @@
+package com.loandesk.service;
+
+import com.loandesk.service.dto.PaymentScheduleEntry;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class LoanCalculatorService {
+
+    public double calculateMonthlyPayment(double principal, double annualRate, int termMonths) {
+        double monthlyRate = annualRate / 12.0 / 100.0;
+        if (monthlyRate == 0) {
+            return principal / termMonths;
+        }
+        double factor = Math.pow(1 + monthlyRate, termMonths);
+        return principal * (monthlyRate * factor) / (factor - 1);
+    }
+
+    public List<PaymentScheduleEntry> generateSchedule(double principal, double annualRate, int termMonths) {
+        double monthlyPayment = calculateMonthlyPayment(principal, annualRate, termMonths);
+        double monthlyRate = annualRate / 12.0 / 100.0;
+        double balance = principal;
+        List<PaymentScheduleEntry> schedule = new ArrayList<>();
+        for (int i = 1; i <= termMonths; i++) {
+            double interest = balance * monthlyRate;
+            double principalPaid = monthlyPayment - interest;
+            balance -= principalPaid;
+            schedule.add(new PaymentScheduleEntry(i,
+                    round(monthlyPayment),
+                    round(principalPaid),
+                    round(interest),
+                    round(Math.max(balance, 0))));
+        }
+        return schedule;
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+}
+

--- a/app/src/main/java/com/loandesk/service/dto/PaymentScheduleEntry.java
+++ b/app/src/main/java/com/loandesk/service/dto/PaymentScheduleEntry.java
@@ -1,0 +1,14 @@
+package com.loandesk.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PaymentScheduleEntry {
+    private int installment;
+    private double payment;
+    private double principal;
+    private double interest;
+    private double balance;
+}

--- a/app/src/main/resources/templates/applications.html
+++ b/app/src/main/resources/templates/applications.html
@@ -6,19 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#0f172a;">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="/">LoanDesk</a>
-        <div class="collapse navbar-collapse">
-            <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="/customers">Customers</a></li>
-                <li class="nav-item"><a class="nav-link" href="/products">Products</a></li>
-                <li class="nav-item"><a class="nav-link" href="/applications">Applications</a></li>
-                <li class="nav-item"><a class="nav-link" th:href="@{/logout}">Logout</a></li>
-            </ul>
-        </div>
-    </div>
-</nav>
+<div th:replace="fragments/navbar :: navbar"></div>
 <div class="container mt-4">
     <h1>Loan Applications</h1>
     <form th:action="@{/applications}" method="post" class="row g-3 mb-4">
@@ -44,7 +32,7 @@
     </form>
     <table class="table table-striped">
         <thead>
-        <tr><th>ID</th><th>Customer</th><th>Product</th><th>Amount</th><th>Status</th><th>Actions</th></tr>
+        <tr><th>ID</th><th>Customer</th><th>Product</th><th>Amount</th><th>Monthly Payment</th><th>Status</th><th>Actions</th></tr>
         </thead>
         <tbody>
         <tr th:each="a : ${applications}">
@@ -52,8 +40,10 @@
             <td th:text="${a.customer.firstName + ' ' + a.customer.lastName}"></td>
             <td th:text="${a.product.name}"></td>
             <td th:text="${a.amount}"></td>
+            <td th:text="${a.monthlyPayment}"></td>
             <td th:text="${a.status}"></td>
             <td>
+                <a th:href="@{'/applications/' + ${a.id} + '/schedule'}" class="btn btn-secondary btn-sm">Schedule</a>
                 <form th:action="@{'/applications/' + ${a.id} + '/approve'}" method="post" style="display:inline">
                     <button class="btn btn-success btn-sm" type="submit">Approve</button>
                 </form>

--- a/app/src/main/resources/templates/customers.html
+++ b/app/src/main/resources/templates/customers.html
@@ -6,19 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#0f172a;">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="/">LoanDesk</a>
-        <div class="collapse navbar-collapse">
-            <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="/customers">Customers</a></li>
-                <li class="nav-item"><a class="nav-link" href="/products">Products</a></li>
-                <li class="nav-item"><a class="nav-link" href="/applications">Applications</a></li>
-                <li class="nav-item"><a class="nav-link" th:href="@{/logout}">Logout</a></li>
-            </ul>
-        </div>
-    </div>
-</nav>
+<div th:replace="fragments/navbar :: navbar"></div>
 <div class="container mt-4">
     <h1>Customers</h1>
     <form th:action="@{/customers}" method="post" class="row g-3 mb-4">

--- a/app/src/main/resources/templates/fragments/navbar.html
+++ b/app/src/main/resources/templates/fragments/navbar.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#0f172a;" th:fragment="navbar">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">LoanDesk</a>
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item"><a class="nav-link" href="/customers">Customers</a></li>
+                <li class="nav-item"><a class="nav-link" href="/products">Products</a></li>
+                <li class="nav-item"><a class="nav-link" href="/applications">Applications</a></li>
+                <li class="nav-item"><a class="nav-link" th:href="@{/logout}">Logout</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+</body>
+</html>

--- a/app/src/main/resources/templates/index.html
+++ b/app/src/main/resources/templates/index.html
@@ -6,19 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#0f172a;">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="/">LoanDesk</a>
-        <div class="collapse navbar-collapse">
-            <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="/customers">Customers</a></li>
-                <li class="nav-item"><a class="nav-link" href="/products">Products</a></li>
-                <li class="nav-item"><a class="nav-link" href="/applications">Applications</a></li>
-                <li class="nav-item"><a class="nav-link" th:href="@{/logout}">Logout</a></li>
-            </ul>
-        </div>
-    </div>
-</nav>
+<div th:replace="fragments/navbar :: navbar"></div>
 <div class="container mt-4">
     <h1>Welcome to LoanDesk</h1>
     <p>Select a module from the navigation bar to get started.</p>

--- a/app/src/main/resources/templates/products.html
+++ b/app/src/main/resources/templates/products.html
@@ -6,19 +6,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark" style="background-color:#0f172a;">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="/">LoanDesk</a>
-        <div class="collapse navbar-collapse">
-            <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="/customers">Customers</a></li>
-                <li class="nav-item"><a class="nav-link" href="/products">Products</a></li>
-                <li class="nav-item"><a class="nav-link" href="/applications">Applications</a></li>
-                <li class="nav-item"><a class="nav-link" th:href="@{/logout}">Logout</a></li>
-            </ul>
-        </div>
-    </div>
-</nav>
+<div th:replace="fragments/navbar :: navbar"></div>
 <div class="container mt-4">
     <h1>Products</h1>
     <form th:action="@{/products}" method="post" class="row g-3 mb-4">

--- a/app/src/main/resources/templates/schedule.html
+++ b/app/src/main/resources/templates/schedule.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Schedule - LoanDesk</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body>
+<div th:replace="fragments/navbar :: navbar"></div>
+<div class="container mt-4">
+    <h1>Amortization Schedule</h1>
+    <p>
+        <strong th:text="${app.customer.firstName + ' ' + app.customer.lastName}"></strong>
+        - <span th:text="${app.product.name}"></span>
+    </p>
+    <p>
+        Amount: <span th:text="${app.amount}"></span>,
+        Term: <span th:text="${app.termMonths}"></span> months,
+        Rate: <span th:text="${app.product.interestRateAnnual}"></span>%
+    </p>
+    <table class="table table-striped">
+        <thead>
+        <tr><th>#</th><th>Payment</th><th>Principal</th><th>Interest</th><th>Balance</th></tr>
+        </thead>
+        <tbody>
+        <tr th:each="s : ${schedule}">
+            <td th:text="${s.installment}"></td>
+            <td th:text="${s.payment}"></td>
+            <td th:text="${s.principal}"></td>
+            <td th:text="${s.interest}"></td>
+            <td th:text="${s.balance}"></td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable navbar fragment and replace duplicated markup
- compute monthly payment and amortization schedule for loan applications
- expose schedule via REST and new UI page with monthly payments

## Testing
- `mvn -q -pl app test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a02045088322bea11aff8a284c34